### PR TITLE
incorrect gemspec

### DIFF
--- a/gitlog-md.gemspec
+++ b/gitlog-md.gemspec
@@ -28,5 +28,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'yard'
 
   # Run time dependencies
-  s.add_development_dependency 'gitlab-grit'
+  s.add_runtime_dependency 'gitlab-grit'
 end

--- a/lib/gitlog-md/version.rb
+++ b/lib/gitlog-md/version.rb
@@ -1,5 +1,5 @@
 module GitlogMD
   module Version
-    STRING = '0.0.1'
+    STRING = '0.0.2'
   end
 end


### PR DESCRIPTION
- grit is a runtime dependency, not a development dependency
